### PR TITLE
Add SVG generation, additional args, and perf improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 bin/
 obj/
+.vs

--- a/Arguments.cs
+++ b/Arguments.cs
@@ -1,0 +1,25 @@
+﻿namespace Painter
+{
+    internal class Arguments
+    {
+        internal Arguments(
+            string inputFilePath,
+            string outputFilePath,
+            int iterationCount,
+            bool saveIntermediateImages)
+        {
+            InputFilePath = inputFilePath;
+            OutputFilePath = outputFilePath;
+            IterationCount = iterationCount;
+            SaveIntermediateImages = saveIntermediateImages;
+        }
+
+        internal string InputFilePath { get; }
+
+        internal string OutputFilePath { get; }
+
+        internal int IterationCount { get; }
+
+        internal bool SaveIntermediateImages { get; }
+    }
+}

--- a/Painter.csproj
+++ b/Painter.csproj
@@ -6,8 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0005" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0005" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta13" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
+    <PackageReference Include="Svg" Version="3.2.3" />
   </ItemGroup>
   <ItemGroup>
     <None Remove=".DS_Store" />

--- a/Painter.sln
+++ b/Painter.sln
@@ -1,7 +1,7 @@
 
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Painter", "Painter\Painter.csproj", "{4811FABE-5C5E-4115-AF2D-F806C3EECC97}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Painter", "Painter.csproj", "{4811FABE-5C5E-4115-AF2D-F806C3EECC97}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 
 namespace Painter
 {
@@ -6,13 +7,28 @@ namespace Painter
     {
         static void Main(string[] args)
         {
-            if (args.Length == 0)
+            Arguments arguments;
+            try
             {
-                Console.WriteLine("Usage: Painter <image>");
+                arguments = new Arguments(
+                    args[0],
+                    args[1],
+                    int.Parse(args[2]),
+                    bool.Parse(args[3]));
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Usage: Painter <inputImagePath> <outputImagePath> <iterationCount> <saveIntermediateImages (true/false)>");
                 return;
             }
 
-            new TrianglePainter().Run(args[0]);
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            new TrianglePainter().Run(arguments);
+
+            stopwatch.Stop();
+            Console.WriteLine($"Operation completed in {stopwatch.ElapsedMilliseconds} ms");
         }
     }
 }

--- a/SVG.cs
+++ b/SVG.cs
@@ -1,0 +1,65 @@
+﻿using SixLabors.ImageSharp.PixelFormats;
+using Svg;
+using System.Drawing;
+
+namespace Painter
+{
+    internal class SVG
+    {
+        private readonly SvgDocument svg;
+        private readonly SvgGroup svgGroup;
+        private readonly int inputWidth;
+        private readonly int inputHeight;
+
+        internal SVG(int inputWidth, int inputHeight)
+        {
+            this.inputWidth = inputWidth;
+            this.inputHeight = inputHeight;
+
+            svg = new SvgDocument
+            {
+                Width = inputWidth,
+                Height = inputHeight
+            };
+
+            svgGroup = new SvgGroup();
+            svg.Children.Add(svgGroup);
+        }
+
+        internal void DrawTriangle(Triangle triangle, Rgba32 color)
+        {
+            svgGroup.Children.Add(new SvgPolygon
+            {
+                Points = new SvgPointCollection
+                {
+                    new SvgUnit(triangle.V1.X), new SvgUnit(triangle.V1.Y),
+                    new SvgUnit(triangle.V2.X), new SvgUnit(triangle.V2.Y),
+                    new SvgUnit(triangle.V3.X), new SvgUnit(triangle.V3.Y),
+                    new SvgUnit(triangle.V1.X), new SvgUnit(triangle.V1.Y),
+                },
+                Fill = new SvgColourServer(Color.FromArgb(color.A, color.R, color.G, color.B))
+            });
+        }
+
+        internal void Fill(Rgba32 color)
+        {
+            svgGroup.Children.Add(new SvgPolygon
+            {
+                Points = new SvgPointCollection
+                {
+                    new SvgUnit(0), new SvgUnit(0),
+                    new SvgUnit(inputWidth), new SvgUnit(0),
+                    new SvgUnit(inputWidth), new SvgUnit(inputHeight),
+                    new SvgUnit(0), new SvgUnit(inputHeight),
+                    new SvgUnit(0), new SvgUnit(0),
+                },
+                Fill = new SvgColourServer(Color.FromArgb(color.A, color.R, color.G, color.B))
+            });
+        }
+
+        internal void Save(string filePath)
+        {
+            svg.Write(filePath);
+        }
+    }
+}

--- a/State.cs
+++ b/State.cs
@@ -26,6 +26,10 @@ namespace Painter
 
         public Triangle InitialState { get; set; }
 
+        public int ImageWidth { get; set; }
+
+        public int ImageHeight { get; set; }
+
         // Indexers
         // Methods
         // Structs

--- a/Triangle.cs
+++ b/Triangle.cs
@@ -43,23 +43,23 @@ namespace Painter
         // Indexers
         // Methods
 
-        public static Triangle Perturb(Triangle triangle, int radius)
+        public static Triangle Perturb(Triangle triangle, int radius, int width, int height)
         {
             var v1 = Vector2.Perturb(triangle.V1, radius);
             var v2 = Vector2.Perturb(triangle.V2, radius);
             var v3 = Vector2.Perturb(triangle.V3, radius);
 
-            v1.Clamp();
-            v2.Clamp();
-            v3.Clamp();
+            v1.Clamp(width, height);
+            v2.Clamp(width, height);
+            v3.Clamp(width, height);
 
             return new Triangle(v1, v2, v3);
         }
 
-        public static Triangle Random(int size)
+        public static Triangle Random(int size, int width, int height)
         {
             var rng = new Random();
-            var position = Vector2.Random();
+            var position = Vector2.Random(width, height);
 
             var v1 = new Vector2(
                 position.X + rng.Next(-size, size),
@@ -71,9 +71,9 @@ namespace Painter
                 position.X + rng.Next(-size, size),
                 position.Y + rng.Next(-size, size));
 
-            v1.Clamp();
-            v2.Clamp();
-            v3.Clamp();
+            v1.Clamp(width, height);
+            v2.Clamp(width, height);
+            v3.Clamp(width, height);
 
             return new Triangle(v1, v2, v3);
         }
@@ -98,7 +98,7 @@ namespace Painter
 
         public override string ToString()
         {
-            return $"{V1.X},{V1.Y}, {V2.X},{V2.Y}, {V2.X},{V2.Y}";
+            return $"{V1.X},{V1.Y}, {V2.X},{V2.Y}, {V3.X},{V3.Y}";
         }
 
         // Structs

--- a/Vector2.cs
+++ b/Vector2.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using SixLabors.Primitives;
+﻿using SixLabors.ImageSharp;
+using System;
 
 namespace Painter
 {
@@ -46,13 +46,13 @@ namespace Painter
                 v.Y + ((float)Math.Sin(angle) * radius));
         }
 
-        public static Vector2 Random()
+        public static Vector2 Random(int imageWidth, int imageHeight)
         {
             var rng = new Random();
 
             return new Vector2(
-                rng.Next(0, Image.Size),
-                rng.Next(0, Image.Size));
+                rng.Next(0, imageWidth),
+                rng.Next(0, imageHeight));
         }
 
         public static implicit operator PointF(Vector2 v)
@@ -60,16 +60,16 @@ namespace Painter
             return new PointF(v.X, v.Y);
         }
 
-        public void Clamp()
+        public void Clamp(int imageWidth, int imageHeight)
         {
-            if (X > Image.Size)
-                X = Image.Size;
+            if (X > imageWidth)
+                X = imageWidth;
 
             if (X < 0)
                 X = 0;
 
-            if (Y > Image.Size)
-                Y = Image.Size;
+            if (Y > imageHeight)
+                Y = imageHeight;
 
             if (Y < 0)
                 Y = 0;


### PR DESCRIPTION
- Will now generate an .svg image in addition to a .png
- Instead of squashing the input image into a 256x256 square, it will now maintain its correct aspect ratio. The height will be 256, and the width will be calculated based on the input image's aspect ratio.
- Added an `iterationCount` parameter to control the number of triangles to be generated in the new image
- Improved the performance of various methods inside the `Image` class by replacing the ImageSharp array index method with their [per-row based iteration methods](https://docs.sixlabors.com/articles/imagesharp/pixelbuffers.html) - testing shows that runtime is cut about in half
- Added some code to output the runtime in ms after completion
- Added some retry code when saving files to avoid transient I/O failures